### PR TITLE
Remove braces on line 154.

### DIFF
--- a/lib/awshelper/cli.rb
+++ b/lib/awshelper/cli.rb
@@ -151,7 +151,7 @@ def snap_email(to, from, email_server, subject='EBS Backups')
   rows = 20
   rows = options[:rows] if options[:rows]
   owner = {}
-  owner = {:owner, options[:owner]} if options[:owner]
+  owner = :owner, options[:owner] if options[:owner]
   message = ""
   log("Report on snapshots")
   # ({ Name="start-time", Values="today in YYYY-MM-DD"})


### PR DESCRIPTION
Without this modification, running ebs_backup.sh with Ruby 1.9.3p484 generates the error below.
I am not a Ruby developer, so take my 'fix' with a grain of salt. The error, however, is real, and this change does silence it.

```
ubuntu@web001:~$ sudo /usr/sbin/ebs_backup.sh
/usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require': /var/lib/gems/1.9.1/gems/aws_helper-0.0.7/lib/awshelper/cli.rb:154: syntax error, unexpected ',', expecting tASSOC (SyntaxError)
  owner = {:owner, options[:owner]} if options[:owner]
                  ^
/var/lib/gems/1.9.1/gems/aws_helper-0.0.7/lib/awshelper/cli.rb:154: syntax error, unexpected '}', expecting keyword_end
  owner = {:owner, options[:owner]} if options[:owner]
                                   ^
    from /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /var/lib/gems/1.9.1/gems/aws_helper-0.0.7/bin/aws_helper:3:in `<top (required)>'
    from /usr/local/bin//aws_helper:23:in `load'
    from /usr/local/bin//aws_helper:23:in `<main>'
/usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require': /var/lib/gems/1.9.1/gems/aws_helper-0.0.7/lib/awshelper/cli.rb:154: syntax error, unexpected ',', expecting tASSOC (SyntaxError)
  owner = {:owner, options[:owner]} if options[:owner]
                  ^
/var/lib/gems/1.9.1/gems/aws_helper-0.0.7/lib/awshelper/cli.rb:154: syntax error, unexpected '}', expecting keyword_end
  owner = {:owner, options[:owner]} if options[:owner]
                                   ^
    from /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /var/lib/gems/1.9.1/gems/aws_helper-0.0.7/bin/aws_helper:3:in `<top (required)>'
    from /usr/local/bin//aws_helper:23:in `load'
    from /usr/local/bin//aws_helper:23:in `<main>'
```
